### PR TITLE
Use JSON_PARTIAL_OUTPUT_ON_ERROR

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -536,7 +536,7 @@ namespace cardgate\api {
 			}
 
 			if ( 'POST' == $sHttpMethod_ ) {
-				$this->_sLastRequest = json_encode( $aData_ );
+				$this->_sLastRequest = json_encode( $aData_, JSON_PARTIAL_OUTPUT_ON_ERROR );
 				curl_setopt( $rCh, CURLOPT_URL, $sUrl );
 				curl_setopt( $rCh, CURLOPT_POST, TRUE );
 				curl_setopt( $rCh, CURLOPT_POSTFIELDS, $this->_sLastRequest );


### PR DESCRIPTION
If the request data contains NaN values, json_encode returns `false`, causing the request to fail, even if the fields containing the NaN values aren't required.

Using `JSON_PARTIAL_OUTPUT_ON_ERROR` prevents this.