### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "cardgate/cardgate-clientlib-php",
 	"description": "CardGate API client library for PHP",
 	"homepage": "https://github.com/cardgate/cardgate-clientlib-php",
-	"version": "1.1.16",
+	"version": "1.1.17",
 	"license": "MIT",
 	"authors": [
 		{
@@ -19,7 +19,7 @@
 		"afterpay", "bitcoin", "directdebit"
 	],
 	"require" : {
-		"php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0",
+		"php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0",
 		"ext-json": "*"
 	},
 	"autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ namespace cardgate\api {
 		/**
 		 * Client version.
 		 */
-		const CLIENT_VERSION = "1.1.16";
+		const CLIENT_VERSION = "1.1.17";
 
 		/**
 		 * Url to use for production.


### PR DESCRIPTION
PHP 8.1 has been out for a while now. It looks like this library works fine with that new version (unsurprisingly, considering nothing changed fundamentally in it) so it would be nice if the package reflects that so we can update our other dependencies.